### PR TITLE
Update geometries.ts

### DIFF
--- a/src/view/renderer/geometries.ts
+++ b/src/view/renderer/geometries.ts
@@ -21,30 +21,9 @@ abstract class DiceShape {
     abstract af: number;
     abstract chamfer: number;
     abstract faces: number[][];
-    labels = [
-        " ",
-        "0",
-        "1",
-        "2",
-        "3",
-        "4",
-        "5",
-        "6",
-        "7",
-        "8",
-        "9",
-        "10",
-        "11",
-        "12",
-        "13",
-        "14",
-        "15",
-        "16",
-        "17",
-        "18",
-        "19",
-        "20"
-    ];
+
+    // An array containing [" ", "0", "1", ... "N"]
+    labels = [" "].concat(Array.from({length: 20}, (_, i) => str(i)));
 
     abstract margin: number;
 


### PR DESCRIPTION
Allows for dice labels to be easily extended past 20 without having a big manually typed list.

I don't know if this is anyway useful😄 I was mostly just looking for some `hacktoberfest` projects to contribute to - and anything bigger seems quite intimidating for someone unfamiliar with typescript. I use the plugin so it would be nice to give back some code. Who knows, maybe it will be updated for quick-access d24s and d30s for all those DCC players out there.