### PR TITLE
Fix dice results displayed as NaN when bigger than 999 (issue #88)

### DIFF
--- a/src/roller/dice.ts
+++ b/src/roller/dice.ts
@@ -551,9 +551,7 @@ export class StackRoller extends GenericRoller<number> {
         switch (this.plugin.data.round) {
             case Round.None: {
                 rounded = Number(
-                    rounded.toLocaleString(navigator.language, {
-                        maximumFractionDigits: 2
-                    })
+                    rounded = Math.trunc(rounded*100)/100;                    
                 );
                 break;
             }


### PR DESCRIPTION
toLocaleString, depending on locale retrieved from the browser, might return a number with thousand separators (i.e. 10,000.54).
Converting it back to Number can fail resulting in NaN value.

Using trunc instead should avoid this problem.

Fixes valentine195/obsidian-dice-roller#88