### PR TITLE
Fix truncated resultText #95

### DIFF
--- a/src/roller/dice.ts
+++ b/src/roller/dice.ts
@@ -538,6 +538,7 @@ export class StackRoller extends GenericRoller<number> {
                 dice.lexeme.text.length +
                 dice.modifierText.length;
         });
+        text.push(this.original.slice(index));
         return text.join("");
     }
     get tooltip() {


### PR DESCRIPTION
dice: (1d4 + 1) leads to the tooltip not showing the closing parenthesis (that is after the last lexeme).

In resultText, just append anything between the end of the last lexeme and the end of the initial text and your parenthesis is/are back.

Issue #95 