### PR TITLE
Fix recalculate (issue #94)

### DIFF
--- a/src/roller/dice.ts
+++ b/src/roller/dice.ts
@@ -830,6 +830,9 @@ export class StackRoller extends GenericRoller<number> {
                 stack.push(new DiceRoller(`${r}`));
             } else {
                 stack.push(item);
+                if (item instanceof DiceRoller) {
+                    item.applyModifiers();
+                }
             }
         }
 


### PR DESCRIPTION
Apply modifiers to all DiceRollers, not only the top level one.