### PR TITLE
Choose initial dice value as Roll, Average or None

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ main.js
 *build.js
 rollup.config-dev.js
 webpack.dev.js
+styles.css
 
 .env

--- a/README.md
+++ b/README.md
@@ -589,6 +589,18 @@ The plugin will use this number as the default face if it is omitted - see [Face
 
 Determine the rounding behavior when decimal numbers are returned.
 
+### Initial Value
+
+Determine the initial value for dice rolls.
+- Roll: result is computed rolling each die.
+- Average: result is computed using the average value for each die.
+-None: result is empty (only the die icon is displayed).
+
+When re-rolling, use Alt-click to set the result to Average,
+Ctrl-click to empty the result or just a click to roll the dice.
+
+Note: this setting does not apply when using rendered dice.
+
 ### Always Render Dice
 
 Dice rolls in notes will always be rendered. Use the [`|norender`](#render-and-norender) flag to prevent this behavior.
@@ -667,7 +679,7 @@ From Obsidian v0.9.8, you can activate this plugin within Obsidian by doing the 
 ## From GitHub
 
 -   Download the Latest Release from the Releases section of the GitHub Repository
--   Extract the plugin folder from the zip to your vault's plugins folder: `<vault>/.obsidian/plugins/`  
+-   Extract the plugin folder from the zip to your vault's plugins folder: `<vault>/.obsidian/plugins/`
     Note: On some machines the `.obsidian` folder may be hidden. On MacOS you should be able to press `Command+Shift+Dot` to show the folder in Finder.
 -   Reload Obsidian
 -   If prompted about Safe Mode, you can disable safe mode and enable the plugin.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "obsidian-dice-roller",
             "version": "8.3.1",
             "license": "MIT",
             "devDependencies": {
@@ -29,7 +30,7 @@
                 "mini-css-extract-plugin": "^2.3.0",
                 "monkey-around": "^2.2.0",
                 "moo": "^0.5.1",
-                "obsidian": "*",
+                "obsidian": "latest",
                 "obsidian-dataview": "^0.4.21",
                 "rollup": "^2.32.1",
                 "rollup-plugin-css-only": "^3.1.0",

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -5,6 +5,7 @@
     cursor: pointer;
 
     margin: 0 0.25em 0 0;
+    vertical-align: top;
 }
 .dice-roller.no-icon {
     margin: 0;

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,7 @@ import { BasicRoller } from "./roller/roller";
 import DiceView, { VIEW_TYPE } from "./view/view";
 import DiceRenderer from "./view/renderer";
 import Lexer, { LexicalToken } from "./parser/lexer";
-import { Round } from "./types";
+import { ExpectedResult, Round } from "./types";
 
 String.prototype.matchAll =
     String.prototype.matchAll ||
@@ -107,6 +107,7 @@ interface DiceRollerSettings {
     customFormulas: string[];
 
     round: keyof typeof Round;
+    expectedResult: keyof typeof ExpectedResult;
 }
 
 export const DEFAULT_SETTINGS: DiceRollerSettings = {
@@ -129,7 +130,8 @@ export const DEFAULT_SETTINGS: DiceRollerSettings = {
     textColor: "#ffffff",
     showLeafOnStartup: true,
     showDice: true,
-    round: Round.None
+    round: Round.None,
+    expectedResult: ExpectedResult.Roll
 };
 
 export default class DiceRollerPlugin extends Plugin {

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -6,7 +6,7 @@ import {
     Setting,
     TextComponent
 } from "obsidian";
-import { Round } from "src/types";
+import { Round, ExpectedResult } from "src/types";
 import type DiceRoller from "../main";
 import { DEFAULT_SETTINGS } from "../main";
 
@@ -138,6 +138,17 @@ export default class SettingTab extends PluginSettingTab {
                     .setValue(this.plugin.data.round)
                     .onChange((v: keyof typeof Round) => {
                         this.plugin.data.round = v;
+                        this.plugin.saveSettings();
+                    });
+            });
+            new Setting(containerEl)
+            .setName("Initial Value")
+            .setDesc("Determine the initial value for dice rolls.")
+            .addDropdown((d) => {
+                d.addOptions(ExpectedResult)
+                    .setValue(this.plugin.data.expectedResult)
+                    .onChange((v: keyof typeof ExpectedResult) => {
+                        this.plugin.data.expectedResult = v;
                         this.plugin.saveSettings();
                     });
             });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,3 +31,9 @@ export enum Round {
     Up = "Up",
     Down = "Down"
 }
+
+export enum ExpectedResult {
+    Roll = "Roll",
+    Average = "Average",
+    None = "None"
+}


### PR DESCRIPTION
- Add user setting to determine the initial value for dice
  rolls.
- Options are: None (result is empty), Average (result is the
  dice average value), Roll (result is random).
- Roll is the default value for Initial Value.
- This setting applies only for the first roll, afterwards
  results are based on random rolls.
- Tooltip and formula indicates when Average or None values have
  been used.
- This does not apply when using rendered dice.

- When re-rolling, using Alt-click sets the result to the Average
  and Ctrl-click sets it to None.

This might address issue #98.

Jeremy, a few doubts for you to double-check (if you're interested by this pull-request):
- I added styles.css in .gitignore, not sure about your flow and why it wasn't there
- package-lock.json has been changed, not sure why!
- In DiceRoller, you were initializing min to null in the constructor, not sure what was the intent, I changed this to be able to compute the average without dealing with a special case

Feel free to drop what you don't want (ctrl or alt clicks for example), and/or to contact me if you want to discuss anything.

Thanks,
JYC

