### PR TITLE
Fix display glitch when using |none (issue #108)

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -5,6 +5,7 @@
     cursor: pointer;
 
     margin: 0 0.25em 0 0;
+    vertical-align: top;
 }
 .dice-roller.no-icon {
     margin: 0;


### PR DESCRIPTION
- Update dice-roller css to ensure that empty div won't break the
  rendering (elements are base-aligned by default, and an empty div
  makes the rendering ... not very good).
  Just setting vertical-align: top fixes this issue.