### PR TITLE
Escape pipe processing for nested tables 

### DIFF
--- a/src/roller/table.ts
+++ b/src/roller/table.ts
@@ -140,8 +140,9 @@ export class TableRoller extends GenericFileRoller<string> {
 
                     this.lookupRanges = table.rows.map((row) => {
                         const [range, option] = row
+                            .replace(/\\\|/g, "{ESCAPED_PIPE}")
                             .split("|")
-                            .map((str) => str.replace("{ESCAPED_PIPE}", "|"))
+                            .map((str) => str.replace("{ESCAPED_PIPE}", "\\|"))
                             .map((s) => s.trim());
 
                         let [, min, max] =
@@ -209,7 +210,7 @@ function extract(content: string) {
             .trim()
             .replace(/\\\|/g, "{ESCAPED_PIPE}")
             .split(SPLIT)
-            .map((e) => e.replace(/{ESCAPED_PIPE}/g, "|"))
+            .map((e) => e.replace(/{ESCAPED_PIPE}/g, "\\|"))
             .map((e) => e.trim())
             .filter((e) => e.length);
 


### PR DESCRIPTION
- After splitting using pipe, replace the temporary pattern
  used to ignore the escaped pipe by an escaped pipe (and not a
  simple pipe)
- When dealing with lookup tables, replace escaped pipes before
  splitting too.

Sequel of #102