### PR TITLE
Header misdetection in TableRoller (#112)

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,7 +1,7 @@
 export const TAG_REGEX =
     /(?:(?<roll>\d+)[Dd])?#(?<tag>[\p{Letter}\p{Emoji_Presentation}\w/-]+)(?:\|(?<collapse>[\+-]))?(?:\|(?<types>[^\+-]+))?/u;
 export const TABLE_REGEX =
-    /(?:(?<roll>\d+)[Dd])?(?:\[.*\]\(|\[\[)(?<link>.+?)#?\^(?<block>.+?)(?:\]\]|\))\|?(?<header>.+)?/;
+    /(?:(?<roll>\d+)[Dd])?(?:\[.*\]\(|\[\[)(?<link>.+?)#?\^(?<block>.+?)(?:\]\]|\))(?:\|(?<header>.+))?/
 export const SECTION_REGEX =
     /(?:(?<roll>\d+)[Dd])?(?:\[.*\]\(|\[\[)(?<link>.+)(?:\]\]|\))\|?(?<types>.+)?/;
 export const MATH_REGEX = /[\(\^\+\-\*\/\)]/;


### PR DESCRIPTION
- regex captures anything after a wiki link as a header
  (including trailing spaces)
- fix regex to capture header only if prefixed with a pipe