### PR TITLE
TableRoller redesign

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -13,9 +13,9 @@
 .dice-roller > div {
     display: inline-block;
 }
-.dice-roller span {
+/* .dice-roller span {
     font-weight: 700;
-}
+} */
 .dice-roller > .dice-roller-button {
     display: inline-block;
     position: relative;
@@ -107,7 +107,7 @@
 
 .dice-roller-result .embedded-table-result p {
     margin: 0;
-    display: inline-flex;
+    /* display: inline-flex; */
 }
 
 /** Settings */

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -13,9 +13,9 @@
 .dice-roller > div {
     display: inline-block;
 }
-/* .dice-roller span {
+.dice-roller span {
     font-weight: 700;
-} */
+}
 .dice-roller > .dice-roller-button {
     display: inline-block;
     position: relative;

--- a/src/main.ts
+++ b/src/main.ts
@@ -710,7 +710,7 @@ export default class DiceRollerPlugin extends Plugin {
                     source,
                     showDice
                 );
-                await roller.initPromise;
+                await roller.init;
                 return roller;
             }
             case "section": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -284,7 +284,7 @@ export default class DiceRollerPlugin extends Plugin {
                                 .replace("|form", "");
 
                             //build result map;
-                            const roller = this.getRoller(
+                            const roller = await this.getRoller(
                                 content,
                                 ctx.sourcePath
                             );
@@ -343,7 +343,7 @@ export default class DiceRollerPlugin extends Plugin {
                         );
 
                         //build result map;
-                        const roller = this.getRoller(content, ctx.sourcePath);
+                        const roller = await this.getRoller(content, ctx.sourcePath);
                         const savedResult =
                             this.data.results?.[path]?.[lineStart]?.[index] ??
                             null;
@@ -603,7 +603,7 @@ export default class DiceRollerPlugin extends Plugin {
         roller.recalculate();
     }
     public async parseDice(content: string, source: string) {
-        const roller = this.getRoller(content, source);
+        const roller = await this.getRoller(content, source);
         return { result: await roller.roll(), roller };
     }
     clearEmpties(o: Record<any, any>) {
@@ -631,11 +631,11 @@ export default class DiceRollerPlugin extends Plugin {
 
         return new RegExp(`(${fields.join("|")})`, "g");
     }
-    getRoller(
+    async getRoller(
         content: string,
         source: string,
         icon = this.data.showDice
-    ): BasicRoller {
+    ): Promise<BasicRoller> {
         content = content.replace(/\\\|/g, "|");
 
         let showDice = content.includes("|nodice") ? false : icon;
@@ -703,13 +703,15 @@ export default class DiceRollerPlugin extends Plugin {
                 return roller;
             }
             case "table": {
-                return new TableRoller(
+                const roller = new TableRoller(
                     this,
                     content,
                     lexemes[0],
                     source,
                     showDice
                 );
+                await roller.initPromise;
+                return roller;
             }
             case "section": {
                 return new SectionRoller(

--- a/src/roller/roller.ts
+++ b/src/roller/roller.ts
@@ -102,6 +102,7 @@ export abstract class GenericFileRoller<T> extends GenericRoller<T> {
     cache: CachedMetadata;
     options: T[];
     results: T[];
+    initPromise: Promise<void>;
     constructor(
         public plugin: DiceRollerPlugin,
         public original: string,
@@ -112,7 +113,7 @@ export abstract class GenericFileRoller<T> extends GenericRoller<T> {
         super(plugin, original, [lexeme], showDice);
 
         this.getPath();
-        this.getFile();
+        this.initPromise = this.getFile();
     }
     abstract getPath(): void;
     async getFile() {

--- a/src/roller/roller.ts
+++ b/src/roller/roller.ts
@@ -102,7 +102,7 @@ export abstract class GenericFileRoller<T> extends GenericRoller<T> {
     cache: CachedMetadata;
     options: T[];
     results: T[];
-    initPromise: Promise<void>;
+    init: Promise<void>;
     constructor(
         public plugin: DiceRollerPlugin,
         public original: string,
@@ -113,7 +113,7 @@ export abstract class GenericFileRoller<T> extends GenericRoller<T> {
         super(plugin, original, [lexeme], showDice);
 
         this.getPath();
-        this.initPromise = this.getFile();
+        this.init = this.getFile();
     }
     abstract getPath(): void;
     async getFile() {

--- a/src/roller/table.ts
+++ b/src/roller/table.ts
@@ -4,6 +4,11 @@ import { TABLE_REGEX } from "src/utils/constants";
 import { StackRoller } from ".";
 import { GenericFileRoller } from "./roller";
 
+class SubRollerResult {
+    result: string;
+    combinedTooltip: string;
+}
+
 export class TableRoller extends GenericFileRoller<string> {
     content: string;
     position: Pos;
@@ -12,6 +17,8 @@ export class TableRoller extends GenericFileRoller<string> {
     isLookup: any;
     lookupRoller: StackRoller;
     lookupRanges: [range: [min: number, max: number], option: string][];
+    combinedTooltip: string = "";
+    prettyTooltip: string = "";
     getPath() {
         const { groups } = this.lexeme.value.match(TABLE_REGEX);
 
@@ -27,9 +34,7 @@ export class TableRoller extends GenericFileRoller<string> {
         this.header = header;
     }
     get tooltip() {
-        return `${this.original}\n${this.path} > ${this.block}${
-            this.header ? " | " + this.header : ""
-        }`;
+        return this.prettyTooltip;
     }
     get replacer() {
         return this.result;
@@ -38,11 +43,9 @@ export class TableRoller extends GenericFileRoller<string> {
     async build() {
         this.resultEl.empty();
         const result = [this.result];
-
         if (this.plugin.data.displayResultsInline) {
             result.unshift(this.inlineText);
         }
-
         MarkdownRenderer.renderMarkdown(
             result.join(""),
             this.resultEl.createSpan("embedded-table-result"),
@@ -50,28 +53,138 @@ export class TableRoller extends GenericFileRoller<string> {
             null
         );
     }
-    async getResult() {
-        if (this.isLookup) {
-            const result = await this.lookupRoller.roll();
-            const option = this.lookupRanges.find(
-                ([range]) =>
-                    (range[1] === undefined && result === range[0]) ||
-                    (result >= range[0] && range[1] >= result)
-            );
-            if (option) {
-                return option[1];
+
+    // Quick and Dirty
+    // TODO: to be refactored (using regex maybe?)
+    prettify(input: string): string {
+        let tab = "\t";
+
+        let tabCount = 0;
+        let output:string = "";
+
+        for (let i = 0; i < input.length; i++) {
+            if (input.charAt(i) == "(") {
+                tabCount++;
+                output += "(\n";
+                output += tab.repeat(tabCount);
+            }
+            else if (input.charAt(i) == ")") {
+                tabCount--;
+                output += "\n";
+                output += tab.repeat(tabCount);
+                output += ")";
+            }
+            else if (input.charAt(i) == ";") {
+                output += ",\n";
+                output += tab.repeat(tabCount);
+            }
+            else if (input.charAt(i) == "|" && input.charAt(i-1) == "|") {
+                output += "|\n";
+                output += tab.repeat(tabCount);
+            }
+            else {
+                output += input.charAt(i);
             }
         }
-        const options = [...this.options];
+        return output;
+    }
 
-        return [...Array(this.rolls)]
-            .map(() => {
-                let option =
-                    options[this.getRandomBetween(0, options.length - 1)];
-                options.splice(options.indexOf(option), 1);
-                return option;
-            })
-            .join("||");
+    async getSubResult(input: string): Promise<SubRollerResult> {
+        let res: SubRollerResult = new SubRollerResult();
+        res.result = input;
+
+        let subTooltips: string[] = [];
+
+        // WARN: we may receive an input that is not string (but a number). Check
+        // for embeded formulas only if we can.
+        if (typeof input?.matchAll === "function") {
+            // Look for dice blocks: `dice: <formula>`
+            const rollerPattern = /(?:\`dice:)(.*?)(?:\`)/g;
+            const foundRollers = input.matchAll(rollerPattern);
+
+            for (let foundRoller of foundRollers) {
+                const formula = foundRoller[1].trim();
+
+                // Create sub roller with formula
+                const subRoller = await this.plugin.getRoller(formula, this.source);
+                // Roll it
+                await subRoller.roll();
+                // Get sub result
+                const rollerResult = await this.getSubResult(subRoller.result);
+
+                // Replace dice block by sub result
+                res.result = res.result.replace(foundRoller[0], rollerResult.result);
+
+                // Update tooltip
+                if (subRoller instanceof TableRoller) {
+                    subTooltips.push(subRoller.combinedTooltip);
+                }
+                else {
+                    const [top, bottom] = subRoller.tooltip.split("\n");
+                    subTooltips.push(top + " --> " + bottom);
+                }
+            }
+        }
+
+        res.combinedTooltip = subTooltips.join(";");
+
+        return res;
+    }
+
+    async getResult() {
+        let res = [];
+
+        let subTooltips: string[] = [];
+
+        for (let i = 0; i < this.rolls; i++) {
+            let subTooltip:string;
+            let subResult: SubRollerResult;
+            let selectedOption:string;
+
+            if (this.isLookup) {
+                const result = await this.lookupRoller.roll();
+                const option = this.lookupRanges.find(
+                    ([range]) =>
+                        (range[1] === undefined && result === range[0]) ||
+                        (result >= range[0] && range[1] >= result)
+                );
+                if (option) {
+                    subTooltip = this.lookupRoller.original.trim() + " --> " + `${this.lookupRoller.resultText}${this.header ? " | " + this.header : ""}`.trim();
+                    selectedOption = option[1];
+                }
+            }
+            else {
+                const options = [...this.options];
+                const randomRowNumber = this.getRandomBetween(0, options.length - 1);
+                // TODO: to be confirmed (was this to forbid rolling the same result twice ?)
+                // options.splice(options.indexOf(option), 1);
+                subTooltip = options.length + " rows" + " --> " + "[row " + (randomRowNumber+1) + "]";
+                selectedOption = options[randomRowNumber];
+            }
+
+            subResult = await this.getSubResult(selectedOption);
+            res.push(subResult.result);
+
+            if (subResult.combinedTooltip) {
+                subTooltip += " > (" + subResult.combinedTooltip + ")";
+            }
+            subTooltips.push(subTooltip);
+        }
+
+        // TODO: find a simpler way
+        if (subTooltips.length == 0) {
+            this.combinedTooltip = this.original;
+        }
+        else if (subTooltips.length == 1) {
+            this.combinedTooltip = this.original + " " + subTooltips.join("");
+        }
+        else {
+            this.combinedTooltip = this.original + " ==> (" + subTooltips.join(" ||") + ")";
+        }
+
+        this.prettyTooltip = this.prettify(this.combinedTooltip);
+
+        return res.join("||");
     }
     async roll(): Promise<string> {
         return new Promise(async (resolve) => {
@@ -130,13 +243,14 @@ export class TableRoller extends GenericFileRoller<string> {
                 Object.keys(table.columns).length === 2 &&
                 /dice:\s*([\s\S]+)\s*?/.test(Object.keys(table.columns)[0])
             ) {
-                const roller = this.plugin.getRoller(
+                const roller = await this.plugin.getRoller(
                     Object.keys(table.columns)[0].split(":").pop(),
                     this.source
                 );
                 if (roller instanceof StackRoller) {
                     this.lookupRoller = roller;
-                    await this.lookupRoller.roll();
+                    // TODO: useless roll I think
+                    // let result = await this.lookupRoller.roll();
 
                     this.lookupRanges = table.rows.map((row) => {
                         const [range, option] = row

--- a/src/roller/table.ts
+++ b/src/roller/table.ts
@@ -5,8 +5,8 @@ import { StackRoller } from ".";
 import { GenericFileRoller } from "./roller";
 
 class SubRollerResult {
-    result: string;
-    combinedTooltip: string;
+    result: string="";
+    combinedTooltip: string="";
 }
 
 export class TableRoller extends GenericFileRoller<string> {
@@ -92,10 +92,14 @@ export class TableRoller extends GenericFileRoller<string> {
         return output;
     }
 
-    async getSubResult(input: string): Promise<SubRollerResult> {
+    async getSubResult(input: string | number): Promise<SubRollerResult> {
         let res: SubRollerResult = new SubRollerResult();
-        res.result = input;
-
+        if (typeof input === "number") {
+            res.result = input.toString();
+        }
+        else {
+            res.result = input;
+        }
         let subTooltips: string[] = [];
 
         // WARN: we may receive an input that is not string (but a number). Check
@@ -140,9 +144,9 @@ export class TableRoller extends GenericFileRoller<string> {
         let subTooltips: string[] = [];
 
         for (let i = 0; i < this.rolls; i++) {
-            let subTooltip:string;
+            let subTooltip:string = "";
             let subResult: SubRollerResult;
-            let selectedOption:string;
+            let selectedOption:string = "";
 
             if (this.isLookup) {
                 const result = await this.lookupRoller.roll();


### PR DESCRIPTION
- Redesign TableRoller not to use recursive rendering of embedded
  sub rollers but, instead, execute them and consolidate the result
  (and the execution steps in the tooltip).
- Support multiple rolls in lookup case too (was only available for
  non lookup case).
- Address async issue with GenericFileRoller

See issue #116 